### PR TITLE
Move the canary tests to a testing framework

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ this_dir="$(dirname -- "$( readlink -f -- "$0"; )")";
 echo "this_dir is $this_dir"
 pushd "$this_dir" > /dev/null
 
-pip install viam-sdk
+pip install -r requirements.txt
 
 # Install the RDK server
 curl "https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-latest-$(uname -i).AppImage" -o viam-server

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+parameterized==0.9.0
+viam-sdk==0.2.18

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -18,13 +18,13 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
             dial_options=DialOptions(credentials=conf.creds)
         )
         self.robot = await RobotClient.at_address(conf.address, opts)
-        board = Board.from_robot(robot, "board")
+        board = Board.from_robot(self.robot, "board")
         self.input_pin = await board.gpio_pin_by_name(conf.INPUT_PIN)
         self.interrupt = await board.digital_interrupt_by_name(conf.INPUT_PIN)
         self.output_pin = await board.gpio_pin_by_name(conf.OUTPUT_PIN)
 
     async def asyncTearDown(self):
-        await output_pin.set(False)
+        await self.output_pin.set(False)
         await self.robot.close()
 
     @parameterized.expand(((True,), (False,)))
@@ -34,7 +34,6 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, value)
 
     async def test_interrupts(self):
-        print("Testing interrupts...")
         FREQUENCY = 50 # Hertz
         DURATION = 2 # seconds
         ERROR_FACTOR = 0.05

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -17,18 +17,19 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
             dial_options=DialOptions(credentials=conf.creds)
         )
         self.robot = await RobotClient.at_address(conf.address, opts)
+        self.input_pin = await board.gpio_pin_by_name(conf.INPUT_PIN)
+        self.interrupt = await board.digital_interrupt_by_name(conf.INPUT_PIN)
+        self.output_pin = await board.gpio_pin_by_name(conf.OUTPUT_PIN)
 
     async def asyncTearDown(self):
         await output_pin.set(False)
         await self.robot.close()
 
-
-async def test_gpios(input_pin, output_pin):
-    for value in (True, False):
-        print("Testing GPIO pin going {}...".format("high" if value else "low"))
-        await output_pin.set(value)
-        result = await input_pin.get()
-        assert(result == value) # TODO: do this better.
+    async def test_gpios(self):
+        for value in (True, False):
+            await self.output_pin.set(value)
+            result = await self.input_pin.get()
+            self.assertEqual(result, value)
 
 
 async def test_interrupts(interrupt, output_pin):

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import asyncio
+import unittest
 
 from viam.components.board import Board
 from viam.robot.client import RobotClient
@@ -9,17 +10,17 @@ from viam.rpc.dial import DialOptions
 import canary_config as conf
 
 
-async def connect():
-    opts = RobotClient.Options(
-        refresh_interval=0,
-        dial_options=DialOptions(credentials=conf.creds)
-    )
-    return await RobotClient.at_address(conf.address, opts)
+class GpioTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        opts = RobotClient.Options(
+            refresh_interval=0,
+            dial_options=DialOptions(credentials=conf.creds)
+        )
+        self.robot = await RobotClient.at_address(conf.address, opts)
 
-
-async def close_robot(robot: RobotClient):
-    if robot:
-        await robot.close()
+    async def asyncTearDown(self):
+        await output_pin.set(False)
+        await self.robot.close()
 
 
 async def test_gpios(input_pin, output_pin):
@@ -49,10 +50,6 @@ async def test_interrupts(interrupt, output_pin):
     expected_count = FREQUENCY * DURATION
 
     assert(abs(total_count - expected_count) / expected_count <= ERROR_FACTOR)
-
-
-async def reset_pins(input_pin, output_pin):
-    await output_pin.set(False)
 
 
 async def test_everything(robot):

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import asyncio
+from parameterized import parameterized
 import unittest
 
 from viam.components.board import Board
@@ -25,11 +26,11 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         await output_pin.set(False)
         await self.robot.close()
 
-    async def test_gpios(self):
-        for value in (True, False):
-            await self.output_pin.set(value)
-            result = await self.input_pin.get()
-            self.assertEqual(result, value)
+    @parameterized.expand(((True,), (False,)))
+    async def test_gpios(self, value):
+        await self.output_pin.set(value)
+        result = await self.input_pin.get()
+        self.assertEqual(result, value)
 
 
 async def test_interrupts(interrupt, output_pin):

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -32,26 +32,25 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         result = await self.input_pin.get()
         self.assertEqual(result, value)
 
+    async def test_interrupts(self):
+        print("Testing interrupts...")
+        FREQUENCY = 50 # Hertz
+        DURATION = 2 # seconds
+        ERROR_FACTOR = 0.05
 
-async def test_interrupts(interrupt, output_pin):
-    print("Testing interrupts...")
-    FREQUENCY = 50 # Hertz
-    DURATION = 2 # seconds
-    ERROR_FACTOR = 0.05
+        await self.output_pin.set(False) # Turn the output off
+        starting_count = await self.interrupt.value()
 
-    await output_pin.set(False) # Turn the output off
-    starting_count = await interrupt.value()
+        await self.output_pin.set_pwm_frequency(FREQUENCY)
+        await self.output_pin.set_pwm(0.5) # Duty cycle fraction: 0 to 1
+        await asyncio.sleep(DURATION)
+        await self.output_pin.set(False) # Turn the output off again
 
-    await output_pin.set_pwm_frequency(FREQUENCY)
-    await output_pin.set_pwm(0.5) # Duty cycle fraction: 0 to 1
-    await asyncio.sleep(DURATION)
-    await output_pin.set(False) # Turn the output off again
+        ending_count = await self.interrupt.value()
+        total_count = ending_count - starting_count
+        expected_count = FREQUENCY * DURATION
 
-    ending_count = await interrupt.value()
-    total_count = ending_count - starting_count
-    expected_count = FREQUENCY * DURATION
-
-    assert(abs(total_count - expected_count) / expected_count <= ERROR_FACTOR)
+        self.assertLessThan(abs(total_count - expected_count) / expected_count, ERROR_FACTOR)
 
 
 async def test_everything(robot):


### PR DESCRIPTION
I should have done this originally! but didn't think it through enough.

Hopefully, if you ignore whitespace changes (everything got indented 1 level), and maybe go commit-by-commit, this is straightforward.

~~TODO: don't merge this until the installer script from https://github.com/viamrobotics/board_canaries/pull/2 is changed to `pip install -r requirements.txt`.~~ edit: done!