### PR TITLE
[RSDK-4766] Fix canary installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ git config --global --add safe.directory "$this_dir"
 pip install -r requirements.txt
 
 # Install the RDK server
-curl "https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-latest-$(uname -i).AppImage" -o viam-server
+curl "https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-latest-$(uname -m).AppImage" -o viam-server
 chmod 755 viam-server
 ./viam-server --aix-install
 


### PR DESCRIPTION
Apparently `uname -i` is not guaranteed to work on all platforms, while `uname -m` is. For every board I've tried except the Beaglebone (Orin, Orin Nano, Odroid, rpi, and my Framework laptop), they provide identical output. On the Beaglebone, `-i` gives back "unknown" while `-m` gives back useful data.