### PR TITLE
[RSDK-4766] give the option of specifying other pins for PWM/interrupts

### DIFF
--- a/canary_config.example.py
+++ b/canary_config.example.py
@@ -4,6 +4,10 @@ from viam.rpc.dial import Credentials
 INPUT_PIN = "16"
 OUTPUT_PIN = "15"
 
+# Uncomment these if you can't reuse the same two pins for all functionality.
+# PWM_PIN = "17"
+# INTERRUPT_PIN = "18"
+
 creds = Credentials(
     type="robot-location-secret",
     payload="put-the-secret-here")

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -38,7 +38,7 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
             PWM_PIN = conf.OUTPUT_PIN
 
         self.pwm_pin = await board.gpio_pin_by_name(PWM_PIN)
-        self.interrupt = await board.digital_interrupt_by_name(INPUT_PIN)
+        self.interrupt = await board.digital_interrupt_by_name(INTERRUPT_PIN)
 
     async def asyncTearDown(self):
         await self.output_pin.set(False)

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -29,12 +29,12 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         # Otherwise, we'll reuse the same inputs and outputs.
         try:
             INTERRUPT_PIN = conf.INTERRUPT_PIN
-        except NameError:
+        except AttributeError:
             INTERRUPT_PIN = conf.INPUT_PIN
 
         try:
             PWM_PIN = conf.PWM_PIN
-        except NameError:
+        except AttributeError:
             PWM_PIN = conf.OUTPUT_PIN
 
         self.pwm_pin = await board.gpio_pin_by_name(PWM_PIN)

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -24,9 +24,12 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
 
         # Most boards have combination GPIO/PWM/interrupt pins. However, rarely
         # they are separated to different pins (e.g., the Beaglebone AI-64 does
-        # not have GPIO functionality on the PWM pins or vice versa). If you
-        # define them separately, define these extra variables in the config.
-        # Otherwise, we'll reuse the same inputs and outputs.
+        # not have GPIO functionality on the PWM pins or vice versa). We need
+        # two pairs of pins: GPIO (output) pairing with GPIO (input), and PWM
+        # (output) pairing with digital interrupt (input). For boards whose
+        # pins can have multiple functions, you can just define the first pair
+        # and we'll reuse it for both. but if you want to define the two pairs
+        # separately, you can.
         try:
             INTERRUPT_PIN = conf.INTERRUPT_PIN
         except AttributeError:

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -20,8 +20,25 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         self.robot = await RobotClient.at_address(conf.address, opts)
         board = Board.from_robot(self.robot, "board")
         self.input_pin = await board.gpio_pin_by_name(conf.INPUT_PIN)
-        self.interrupt = await board.digital_interrupt_by_name(conf.INPUT_PIN)
         self.output_pin = await board.gpio_pin_by_name(conf.OUTPUT_PIN)
+
+        # Most boards have combination GPIO/PWM/interrupt pins. However, rarely
+        # they are separated to different pins (e.g., the Beaglebone AI-64 does
+        # not have GPIO functionality on the PWM pins or vice versa). If you
+        # define them separately, define these extra variables in the config.
+        # Otherwise, we'll reuse the same inputs and outputs.
+        try:
+            INTERRUPT_PIN = conf.INTERRUPT_PIN
+        except NameError:
+            INTERRUPT_PIN = conf.INPUT_PIN
+
+        try:
+            PWM_PIN = conf.PWM_PIN
+        except NameError:
+            PWM_PIN = conf.OUTPUT_PIN
+
+        self.pwm_pin = await board.gpio_pin_by_name(PWM_PIN)
+        self.interrupt = await board.digital_interrupt_by_name(INPUT_PIN)
 
     async def asyncTearDown(self):
         await self.output_pin.set(False)
@@ -38,13 +55,13 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         DURATION = 2 # seconds
         ERROR_FACTOR = 0.05
 
-        await self.output_pin.set(False) # Turn the output off
+        await self.pwm_pin.set(False) # Turn the output off
         starting_count = await self.interrupt.value()
 
-        await self.output_pin.set_pwm_frequency(FREQUENCY)
-        await self.output_pin.set_pwm(0.5) # Duty cycle fraction: 0 to 1
+        await self.pwm_pin.set_pwm_frequency(FREQUENCY)
+        await self.pwm_pin.set_pwm(0.5) # Duty cycle fraction: 0 to 1
         await asyncio.sleep(DURATION)
-        await self.output_pin.set(False) # Turn the output off again
+        await self.pwm_pin.set(False) # Turn the output off again
 
         ending_count = await self.interrupt.value()
         total_count = ending_count - starting_count


### PR DESCRIPTION
Problem: the Beaglebone AI-64 pins seem to be either GPIO or PWM, but not both. The canary tests want to test both.

Solution: if you only define one set of pins in the test config, use those for everything. If you define a second set, though, do different tests on the different pins.

Tried on an Orin Nano with only 1 set of pins defined: the tests all pass.

Tried on a Beaglebone AI-64 with 2 sets of pins defined: the tests all pass again!