### PR TITLE
make the software PWM test much more forgiving

### DIFF
--- a/test_gpios.py
+++ b/test_gpios.py
@@ -39,7 +39,6 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
             HW_PWM_PIN = conf.HW_PWM_PIN
         except AttributeError:
             HW_PWM_PIN = conf.OUTPUT_PIN
-            
 
         self.hw_pwm_pin = await board.gpio_pin_by_name(HW_PWM_PIN)
         self.hw_interrupt = await board.digital_interrupt_by_name(HW_INTERRUPT_PIN)
@@ -57,10 +56,10 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         await self.output_pin.set(value)
         result = await self.input_pin.get()
         self.assertEqual(result, value)
-    
-    @parameterized.expand((("hw"), ("sw")))
-    async def test_interrupts(self, pwm):
-        FREQUENCY = 50 # Hertz
+
+    @parameterized.expand((("hw",), ("sw",)))
+    async def test_interrupts_and_pwm(self, pwm):
+        FREQUENCY = 40 # Hertz
         DURATION = 2 # seconds
 
         if pwm == "hw":
@@ -70,7 +69,7 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         else:
             pwm_pin = self.sw_pwm_pin
             interrupt = self.sw_interrupt
-            error_factor = 0.07
+            error_factor = 0.10  # Software PWM can get really inaccurate
 
         await pwm_pin.set_pwm_frequency(FREQUENCY)
         await pwm_pin.set_pwm(0.5) # Duty cycle fraction: 0 to 1


### PR DESCRIPTION
A bunch of tiny changes:
- Bump the allowable error up to 10%. The worst error we've seen so far is 9%. I don't like how big it is, but until we redo this to work more accurately, I don't think there's much we can do about it. :disappointed: 
- Reduce the PWM frequency from 50 Hertz to 40. By making it slower, hopefully the computer can keep up with the changes better. (Thanks to Rand for the idea!)
- Remove the trailing whitespace that was added to a couple lines. IIRC you use VSCode: here's [how to do that automatically](https://stackoverflow.com/questions/30884131/remove-trailing-spaces-automatically-or-with-a-shortcut) when you save a file.
- Rename the test to be about interrupts _and PWM._
- Make the `parameterized.expand` arguments tuples. This should hopefully make them easier to read when something fails, because the test names will have the first element of the tuple and no longer have the index of the test. Hopefully the two tests will now be named `test_interrupts_and_pwm_hw` and `test_interrupts_and_pwm_sw`.
