### PR TITLE
turn on Rust backtracing, in case we hit that panic again

### DIFF
--- a/canary_tests.sh
+++ b/canary_tests.sh
@@ -32,6 +32,8 @@ git pull --ff-only origin main # Update the test script if necessary
 pip install -r requirements.txt # Install any new dependencies
 
 echo "running tests..."
+# Try to get more detailed info for https://viam.atlassian.net/browse/RSDK-6252
+export RUST_BACKTRACE=1
 # The cron job that runs our script writes stdout to file. If something goes wrong in the tests, it
 # will be written to stderr. Redirect that to stdout so it gets written to file, too.
 ./test_gpios.py 2>&1


### PR DESCRIPTION
This will help with https://viam.atlassian.net/browse/RSDK-6252 if it happens again.

Not tested: given that we can't reliably reproduce the issue, I don't even know how I'd go about testing it. but my expectation is that this is right, and then we'll get more details next time the panic happens.