### PR TITLE
Log to /var/log instead of /tmp

### DIFF
--- a/analyze_logs.sh
+++ b/analyze_logs.sh
@@ -8,7 +8,7 @@ pushd "$this_dir" > /dev/null
 
 # The sed line keeps only the file contents that match the current date and
 # later. This solution was taken from https://stackoverflow.com/a/7104422
-cat /tmp/canary_tests.log |\
+cat /var/log/canary_tests.log |\
 	sed -n "/$(date '+%Y-%m-%d')/,\$p" |\
 	./analyze_logs.py
 

--- a/crontab_template.txt
+++ b/crontab_template.txt
@@ -5,5 +5,5 @@
 SHELL=/bin/sh
 
 # Even if pulling the latest version of the repo fails, we still want to run the tests.
-30 2 * * *   root   cd CANARY_DIR && git pull --ff-only origin main; ./canary_tests.sh >> /tmp/canary_tests.log 2>&1
-45 2 * * *   root   cd CANARY_DIR && ./analyze_logs.sh >> /tmp/canary_analysis.log 2>&1
+30 2 * * *   root   cd CANARY_DIR && git pull --ff-only origin main; ./canary_tests.sh >> /var/log/canary_tests.log 2>&1
+45 2 * * *   root   cd CANARY_DIR && ./analyze_logs.sh >> /var/log/canary_analysis.log 2>&1


### PR DESCRIPTION
Because this changes the crontab template, we need to manually install this on all the boards. This kind of thing is what [Salt](https://docs.saltproject.io/en/master/topics/tutorials/walkthrough.html#salt-in-10-minutes/) is intended to do. but we have so few boards that it's not worth the hassle to set that up yet.

So, we shouldn't check this in until we're willing to manually update the crontabs on all the board canaries (likely by re-running `install.sh` on each of them). 

For the moment, I'm not adding in anything about log rotation. We add a couple kilobytes to the logs every night, which means we'll add less than a megabyte per year. If we rotate the logs once per decade, that's more than enough. :wink: 