### PR TITLE
Retry connection if it fails

### DIFF
--- a/analyze_logs.py
+++ b/analyze_logs.py
@@ -5,8 +5,9 @@ import slack_reporter
 
 
 if __name__ == "__main__":
-    # Most lines from stdin end in a newline, but maybe not the last one. To give a more uniform
-    # interface, we strip out all trailing whitespace here, and maybe add newlines back later.
+    # Most lines from stdin end in a newline, but maybe not the last one. To
+    # give a more uniform interface, we strip out all trailing whitespace here,
+    # and maybe add newlines back later.
     contents = [line.rstrip() for line in fileinput.input()]
     expected_contents = [
         "OK",

--- a/analyze_logs.py
+++ b/analyze_logs.py
@@ -17,10 +17,10 @@ if __name__ == "__main__":
         "+ exit 0",
         ]
     if contents[-len(expected_contents):] != expected_contents:
-        if contents == []:
+        if contents == [] or contents == [""]:
             slack_reporter.report_message(
                 "the canary tests had no recent output!")
         else:
             text = "the canary tests have failed. Recent output is:"
-            file_contents = "\n".join(output)
+            file_contents = "\n".join(contents)
             slack_reporter.report_file("canary_tests.log", file_contents, text)

--- a/analyze_logs.py
+++ b/analyze_logs.py
@@ -4,33 +4,22 @@ import fileinput # For accessing stdin
 import slack_reporter
 
 
-def report_no_output():
-    slack_reporter.report_message("the canary tests had no recent output!")
-
-
-def report_errors(output):
-    text = "the canary tests have failed. Recent output is:"
-    file_contents = "\n".join(output)
-    slack_reporter.report_file("canary_tests.log", file_contents, text)
-
-
-def tests_succeeded(contents):
-    ideal_end = [
+if __name__ == "__main__":
+    # Most lines from stdin end in a newline, but maybe not the last one. To give a more uniform
+    # interface, we strip out all trailing whitespace here, and maybe add newlines back later.
+    contents = [line.rstrip() for line in fileinput.input()]
+    expected_contents = [
         "OK",
         "+ echo 'done running tests!'",
         "done running tests!",
         "+ popd",
         "+ exit 0",
         ]
-    return contents[-len(ideal_end):] == ideal_end
-
-
-if __name__ == "__main__":
-    # Most lines from stdin end in a newline, but maybe not the last one. To give a more uniform
-    # interface, we strip out all trailing whitespace here, and maybe add newlines back later.
-    contents = [line.rstrip() for line in fileinput.input()]
-    if not tests_succeeded(contents):
+    if contents[-len(expected_contents):] != expected_contents:
         if contents == []:
-            report_no_output()
+            slack_reporter.report_message(
+                "the canary tests had no recent output!")
         else:
-            report_errors(contents)
+            text = "the canary tests have failed. Recent output is:"
+            file_contents = "\n".join(output)
+            slack_reporter.report_file("canary_tests.log", file_contents, text)

--- a/analyze_logs.py
+++ b/analyze_logs.py
@@ -5,14 +5,11 @@ import slack_reporter
 
 
 def report_no_output():
-    text = (f"The canary tests on the {slack_reporter.board_name} board had " +
-             "no recent output!")
-    slack_reporter.report_message(text)
+    slack_reporter.report_message("the canary tests had no recent output!")
 
 
 def report_errors(output):
-    text = (f"The canary tests on the {slack_reporter.board_name} board have " +
-            "failed. Recent output is:")
+    text = "the canary tests have failed. Recent output is:"
     file_contents = "\n".join(output)
     slack_reporter.report_file("canary_tests.log", file_contents, text)
 

--- a/check_slack_connectivity.py
+++ b/check_slack_connectivity.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-import slack_sdk
-
-import slack_reporter_config as config
+import slack_reporter
 
 
 # This is simultaneously:
@@ -11,6 +9,6 @@ import slack_reporter_config as config
 #     canary tests.
 if __name__ == "__main__":
     client = slack_sdk.WebClient(token=config.auth_token)
-    text = (f"Canary tests on the {config.board_name} board should be able " +
-            "to report to Slack!")
+    text = (f"Canary tests on the {slack_reporter.board_name} board should " +
+             "be able to report to Slack!")
     result = client.chat_postMessage(channel=config.channel_id, text=text)

--- a/check_slack_connectivity.py
+++ b/check_slack_connectivity.py
@@ -8,7 +8,5 @@ import slack_reporter
 # 2) an announcement to the Slack channel that there's a new board running
 #     canary tests.
 if __name__ == "__main__":
-    client = slack_sdk.WebClient(token=config.auth_token)
-    text = (f"Canary tests on the {slack_reporter.board_name} board should " +
-             "be able to report to Slack!")
-    result = client.chat_postMessage(channel=config.channel_id, text=text)
+    text = "the canary tests should be able to report to Slack!"
+    result = slack_reporter.report_message(text)

--- a/slack_reporter.py
+++ b/slack_reporter.py
@@ -25,7 +25,7 @@ def report_file(filename, contents, comment):
     text = add_preamble(comment)
     client = slack_sdk.WebClient(token=config.auth_token)
     result = client.files_upload_v2(
-        channel=config.channel_id, content=file_contents, snippet_type="text",
+        channel=config.channel_id, content=contents, snippet_type="text",
         filename="canary_tests.log", initial_comment=text)
     # Again, if things fail we'll raise an exception here, but there is no
     # obvious resolution for that.

--- a/slack_reporter.py
+++ b/slack_reporter.py
@@ -4,12 +4,14 @@ import slack_sdk
 import slack_reporter_config as config
 
 
-# Re-export this value
-board_name = config.board_name
+def add_preamble(message):
+    return f"The {config.board_name} says: {message}"
+
 
 def report_message(message):
+    text = add_preamble(message)
     client = slack_sdk.WebClient(token=config.auth_token)
-    result = client.chat_postMessage(channel=config.channel_id, text=message)
+    result = client.chat_postMessage(channel=config.channel_id, text=text)
     # If we get a result, things worked. Failure raises exceptions instead.
     # Currently, we ignore any errors. The cron job that runs this script
     # will write all our output (including a stack trace from an uncaught
@@ -20,6 +22,7 @@ def report_message(message):
 
 
 def report_file(filename, contents, comment):
+    text = add_preamble(comment)
     client = slack_sdk.WebClient(token=config.auth_token)
     result = client.files_upload_v2(
         channel=config.channel_id, content=file_contents, snippet_type="text",

--- a/slack_reporter.py
+++ b/slack_reporter.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import slack_sdk
+
+import slack_reporter_config as config
+
+
+# Re-export this value
+board_name = config.board_name
+
+def report_message(message):
+    client = slack_sdk.WebClient(token=config.auth_token)
+    result = client.chat_postMessage(channel=config.channel_id, text=message)
+    # If we get a result, things worked. Failure raises exceptions instead.
+    # Currently, we ignore any errors. The cron job that runs this script
+    # will write all our output (including a stack trace from an uncaught
+    # exception) to /tmp/canary_analysis.log, but there's no obvious way to
+    # tell a human to go look at that. How do we report that we're unable to
+    # report stuff!?
+    return result  # Maybe whoever called us knows what to do with this.
+
+
+def report_file(filename, contents, comment):
+    client = slack_sdk.WebClient(token=config.auth_token)
+    result = client.files_upload_v2(
+        channel=config.channel_id, content=file_contents, snippet_type="text",
+        filename="canary_tests.log", initial_comment=text)
+    # Again, if things fail we'll raise an exception here, but there is no
+    # obvious resolution for that.
+    return result
+

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -25,7 +25,7 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
             # There's some race condition in the Python SDK that causes
             # reconnection to fail sometimes.
             slack_reporter.report_message(
-                f"Connection error on the {slack_reporter.board_name}.")
+                "connection error during canary tests. Retrying...")
             time.sleep(1)
             self.robot = await RobotClient.at_address(conf.address, opts)
 

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -9,6 +9,7 @@ from viam.robot.client import RobotClient
 from viam.rpc.dial import DialOptions
 
 import canary_config as conf
+import slack_reporter
 
 
 class GpioTest(unittest.IsolatedAsyncioTestCase):
@@ -17,7 +18,17 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
             refresh_interval=0,
             dial_options=DialOptions(credentials=conf.creds)
         )
-        self.robot = await RobotClient.at_address(conf.address, opts)
+
+        try:
+            self.robot = await RobotClient.at_address(conf.address, opts)
+        except ConnectionError:
+            # There's some race condition in the Python SDK that causes
+            # reconnection to fail sometimes.
+            slack_reporter.report_message(
+                f"Connection error on the {slack_reporter.board_name}.")
+            time.sleep(1)
+            self.robot = await RobotClient.at_address(conf.address, opts)
+
         board = Board.from_robot(self.robot, "board")
         self.input_pin = await board.gpio_pin_by_name(conf.INPUT_PIN)
         self.output_pin = await board.gpio_pin_by_name(conf.OUTPUT_PIN)


### PR DESCRIPTION
The changes are:
- Reporting stuff to Slack has been refactored into a new file, `slack_reporter.py`
- If the canary board tests are unable to connect to the RDK, report that to Slack and then try a second time before failing the test.

I suspect the easiest way to review this is commit-by-commit, though there were a few mistakes I made in early commits that I fixed in later ones without reworking the history.

I haven't tried this out yet, but intend to put it through its paces in the un-archived #temp_to_remove channel...