### PR TITLE
[RSDK-6252] set rust backtracing to full

### DIFF
--- a/canary_tests.sh
+++ b/canary_tests.sh
@@ -33,7 +33,7 @@ pip install -r requirements.txt # Install any new dependencies
 
 echo "running tests..."
 # Try to get more detailed info for https://viam.atlassian.net/browse/RSDK-6252
-export RUST_BACKTRACE=1
+export RUST_BACKTRACE=full
 # The cron job that runs our script writes stdout to file. If something goes wrong in the tests, it
 # will be written to stderr. Redirect that to stdout so it gets written to file, too.
 ./test_gpios.py 2>&1


### PR DESCRIPTION
... in the hopes of getting a better stack trace

The most recent time it crashed, we got this at the end of the stack trace:
```
...
  82: <unknown>
  83: <unknown>
  84: <unknown>
  85: _PyRun_SimpleFileObject
  86: _PyRun_AnyFileObject
  87: Py_RunMain
  88: Py_BytesMain
  89: <unknown>
  90: __libc_start_main
  91: _start
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
fatal runtime error: failed to initiate panic, error 5
```