### PR TITLE
library functions should use their arguments

### DIFF
--- a/slack_reporter.py
+++ b/slack_reporter.py
@@ -26,7 +26,7 @@ def report_file(filename, contents, comment):
     client = slack_sdk.WebClient(token=config.auth_token)
     result = client.files_upload_v2(
         channel=config.channel_id, content=contents, snippet_type="text",
-        filename="canary_tests.log", initial_comment=text)
+        filename=filename, initial_comment=text)
     # Again, if things fail we'll raise an exception here, but there is no
     # obvious resolution for that.
     return result


### PR DESCRIPTION
I noticed this while showing Gautham this file.

There won't be any behavioral changes here: the only place `report_file()` is used, the `filename` passed in is `"canary_tests.log"`. but now it's more correct so we can't hit this bug in the future.