### PR TITLE
Diagnose problems with counting ticks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 parameterized==0.9.0
 slack-sdk==3.21.3
-viam-sdk==0.5.1
+viam-sdk==0.19.0

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -94,7 +94,7 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         # In order to diagnose a flaky test, we're going to record all tick-related data.
         should_stop = asyncio.Event()
         ticks = []
-        counter_task = asyncio.create_task(record_tick_data(tick_stream, ticks, should_stop))
+        counter_task = asyncio.create_task(self.record_tick_data(tick_stream, ticks, should_stop))
 
         await pwm_pin.set_pwm_frequency(FREQUENCY)
         await pwm_pin.set_pwm(0.5) # Duty cycle fraction: 0 to 1
@@ -121,6 +121,7 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         allowable_error = expected_count * error_factor
         self.assertAlmostEqual(total_count, expected_count, delta=allowable_error)
 
+    @staticmethod
     async def record_tick_data(tick_stream, data, should_stop):
         async for tick in tick_stream:
             data.append((tick.time, tick.high, tick.pin_name))

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -91,6 +91,11 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
             interrupt = self.sw_interrupt
             error_factor = 0.10  # Software PWM can get really inaccurate
 
+        # In order to diagnose a flaky test, we're going to record all tick-related data.
+        should_stop = asyncio.Event()
+        ticks = []
+        counter_task = asyncio.create_task(record_tick_data(tick_stream, ticks, should_stop))
+
         await pwm_pin.set_pwm_frequency(FREQUENCY)
         await pwm_pin.set_pwm(0.5) # Duty cycle fraction: 0 to 1
 
@@ -101,13 +106,26 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
 
         starting_count = await interrupt.value()
         await asyncio.sleep(DURATION)
+        should_stop.set()
+
+        await counter_task
         await pwm_pin.set(False) # Turn the output off again
+        print("data from tick stream:")
+        for tick in ticks:
+            print(tick)
+
         ending_count = await interrupt.value()
 
         total_count = ending_count - starting_count
         expected_count = FREQUENCY * DURATION
         allowable_error = expected_count * error_factor
         self.assertAlmostEqual(total_count, expected_count, delta=allowable_error)
+
+    async def record_tick_data(tick_stream, data, should_stop):
+        async for tick in tick_stream:
+            data.append((tick.time, tick.high, tick.pin_name))
+            if should_stop.is_set():
+                return
 
 
 if __name__ == "__main__":

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -38,9 +38,9 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
             time.sleep(5)
             self.robot = await RobotClient.at_address(conf.address, opts)
 
-        board = Board.from_robot(self.robot, "board")
-        self.input_pin = await board.gpio_pin_by_name(conf.INPUT_PIN)
-        self.output_pin = await board.gpio_pin_by_name(conf.OUTPUT_PIN)
+        self.board = Board.from_robot(self.robot, "board")
+        self.input_pin = await self.board.gpio_pin_by_name(conf.INPUT_PIN)
+        self.output_pin = await self.board.gpio_pin_by_name(conf.OUTPUT_PIN)
 
         # Most boards have combination GPIO/PWM/interrupt pins. However, rarely
         # they are separated to different pins (e.g., the Beaglebone AI-64 does
@@ -60,12 +60,12 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         except AttributeError:
             HW_PWM_PIN = conf.OUTPUT_PIN
 
-        self.hw_pwm_pin = await board.gpio_pin_by_name(HW_PWM_PIN)
-        self.hw_interrupt = await board.digital_interrupt_by_name(HW_INTERRUPT_PIN)
+        self.hw_pwm_pin = await self.board.gpio_pin_by_name(HW_PWM_PIN)
+        self.hw_interrupt = await self.board.digital_interrupt_by_name(HW_INTERRUPT_PIN)
 
         # We also need a software pwm pin and interrupt pin pair to test software pwm.
-        self.sw_pwm_pin = await board.gpio_pin_by_name(conf.SW_PWM_PIN)
-        self.sw_interrupt = await board.digital_interrupt_by_name(conf.SW_INTERRUPT_PIN)
+        self.sw_pwm_pin = await self.board.gpio_pin_by_name(conf.SW_PWM_PIN)
+        self.sw_interrupt = await self.board.digital_interrupt_by_name(conf.SW_INTERRUPT_PIN)
 
     async def asyncTearDown(self):
         await self.output_pin.set(False)
@@ -94,6 +94,7 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         # In order to diagnose a flaky test, we're going to record all tick-related data.
         should_stop = asyncio.Event()
         ticks = []
+        tick_stream = await self.board.stream_ticks([interrupt])
         counter_task = asyncio.create_task(self.record_tick_data(tick_stream, ticks, should_stop))
 
         await pwm_pin.set_pwm_frequency(FREQUENCY)

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -108,8 +108,8 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         starting_count = await interrupt.value()
         await asyncio.sleep(DURATION)
         should_stop.set()
-
         await counter_task
+
         await pwm_pin.set(False) # Turn the output off again
         print("data from tick stream:")
         for tick in ticks:

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -109,8 +109,8 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(DURATION)
         should_stop.set()
         await counter_task
-
         await pwm_pin.set(False) # Turn the output off again
+
         print("data from tick stream:")
         for tick in ticks:
             print(tick)


### PR DESCRIPTION
Usually the canary tests pass fine, but sometimes the tick count for the HW PWM stuff is way too low. This PR prints out data about every interrupt we encounter, in the hopes that we can figure out what's going wrong.

Tried on an Orin Nano: works fine. We get lots of ticks printed out, and then the test passes. The cron job will pull the latest code from github, and then run `pip install -r requirements` to upgrade the SDK, so the boards should be able to upgrade themselves.