### PR TITLE
ignore the new extra output when checking if the tests have passed

### DIFF
--- a/analyze_logs.py
+++ b/analyze_logs.py
@@ -9,14 +9,20 @@ if __name__ == "__main__":
     # give a more uniform interface, we strip out all trailing whitespace here,
     # and maybe add newlines back later.
     contents = [line.rstrip() for line in fileinput.input()]
+    # In May 2024, we began logging extra information about interrupt ticks,
+    # to better diagnose a PWM issue on the Orin and Orin Nano. Ignore that
+    # output here.
+    filtered_contents = [line for line in contents if not line.startswith("(")]
     expected_contents = [
         "OK",
+        # TODO: remember to take this out again if we remove the diagnostics!
+        "data from tick stream:",
         "+ echo 'done running tests!'",
         "done running tests!",
         "+ popd",
         "+ exit 0",
         ]
-    if contents[-len(expected_contents):] != expected_contents:
+    if filtered_contents[-len(expected_contents):] != expected_contents:
         if contents == [] or contents == [""]:
             slack_reporter.report_message(
                 "the canary tests had no recent output!")


### PR DESCRIPTION
This is a follow-up to https://github.com/viamrobotics/board_canaries/pull/24, which added new output from the tests to try to better diagnose the flakiness around PWM output. What I forgot was that the later analysis checks that the test output looks right and sends it to Slack if it doesn't. When the test output changed, we started sending it all to Slack! This PR corrects it, so the analysis ignores the new output.

Tried on the Orin AGX: without this change it (erroneously) reports to Slack that last night's test failed, and with the change, it (correctly) says the tests passed.