### PR TITLE
Print stacks on SIGUSR1

### DIFF
--- a/analyze_logs.py
+++ b/analyze_logs.py
@@ -2,6 +2,7 @@
 import fileinput # For accessing stdin
 
 import slack_reporter
+import stack_printing  # Set up the ability to print stack traces on SIGUSR1
 
 
 if __name__ == "__main__":

--- a/stack_printing.py
+++ b/stack_printing.py
@@ -1,0 +1,27 @@
+import signal
+import sys
+import threading
+import traceback
+
+def print_all_stacks(signum, frame):
+    """
+    This is intended as a signal handler. However, we ignore the signal and
+    instead print stack traces of all currently-running threads. The intention
+    here is for a user to be able to send a signal to the process and get useful
+    debugging information out of it.
+
+    This approach is taken from
+    https://stackoverflow.com/questions/132058/showing-the-stack-trace-from-a-running-python-application/2569696#2569696
+    """
+    thread_names = {thread.ident: thread.name for thread in
+            threading.enumerate()}
+    for thread_id, frame in sys._current_frames().items():
+        print(f"Thread {thread_names.get(thread_id, 'Unknown')}:")
+        stack = traceback.extract_stack(frame)
+        for file_name, line_number, function_name, source in stack:
+            print(f"  {file_name}:{line_number} @{function_name}: {source}")
+
+
+# Whenever we receive a SIGUSR1 (the first user-defined interrupt signal), we
+# print stack traces of all running threads.
+signal.signal(signal.SIGUSR1, print_all_stacks)

--- a/stack_printing.py
+++ b/stack_printing.py
@@ -1,3 +1,4 @@
+import asyncio
 import signal
 import sys
 import threading
@@ -20,6 +21,10 @@ def print_all_stacks(signum, frame):
         stack = traceback.extract_stack(frame)
         for file_name, line_number, function_name, source in stack:
             print(f"  {file_name}:{line_number} @{function_name}: {source}")
+
+    # Now, do the same thing for active coroutines.
+    for task in asyncio.all_tasks():
+        task.print_stack()
 
 
 # Whenever we receive a SIGUSR1 (the first user-defined interrupt signal), we

--- a/stack_printing.py
+++ b/stack_printing.py
@@ -20,7 +20,8 @@ def print_all_stacks(signum, frame):
         print(f"Thread {thread_names.get(thread_id, 'Unknown')}:")
         stack = traceback.extract_stack(frame)
         for file_name, line_number, function_name, source in stack:
-            print(f"  {file_name}:{line_number} @{function_name}: {source}")
+            print(f"  File {file_name}, line {line_number}, in @{function_name}")
+            print(f"    {source}")
 
     # Now, do the same thing for active coroutines.
     for task in asyncio.all_tasks():

--- a/test_gpios.py
+++ b/test_gpios.py
@@ -12,6 +12,7 @@ from viam.rpc.dial import DialOptions
 
 import canary_config as conf
 import slack_reporter
+import stack_printing  # Set up the ability to print stack traces on SIGUSR1
 
 
 class GpioTest(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Twice recently, the tests have hung, and it would be nice to figure out _where_ they hung. With this PR, you can send a SIGUSR1 (e.g., `pkill -10 -f test_gpios`) and it'll print out stack traces of all threads and all active coroutines.

I don't have a great sense of how useful this will be: I can get output like the following.
```
Thread asyncio_0:
  File /usr/lib/python3.11/threading.py, line 1002, in @_bootstrap
    self._bootstrap_inner()
  File /usr/lib/python3.11/threading.py, line 1045, in @_bootstrap_inner
    self.run()
  File /usr/lib/python3.11/threading.py, line 982, in @run
    self._target(*self._args, **self._kwargs)
  File /usr/lib/python3.11/concurrent/futures/thread.py, line 83, in @_worker
    work_item.run()
  File /usr/lib/python3.11/concurrent/futures/thread.py, line 58, in @run
    result = self.fn(*self.args, **self.kwargs)
Thread MainThread:
  File /home/alan/viam/board_canaries/./test_gpios.py, line 135, in @<module>
    unittest.main()
  File /usr/lib/python3.11/unittest/main.py, line 102, in @__init__
    self.runTests()
  File /usr/lib/python3.11/unittest/main.py, line 274, in @runTests
    self.result = testRunner.run(self.test)
  File /usr/lib/python3.11/unittest/runner.py, line 217, in @run
    test(result)
  File /usr/lib/python3.11/unittest/suite.py, line 84, in @__call__
    return self.run(*args, **kwds)
  File /usr/lib/python3.11/unittest/suite.py, line 122, in @run
    test(result)
  File /usr/lib/python3.11/unittest/suite.py, line 84, in @__call__
    return self.run(*args, **kwds)
  File /usr/lib/python3.11/unittest/suite.py, line 122, in @run
    test(result)
  File /usr/lib/python3.11/unittest/case.py, line 678, in @__call__
    return self.run(*args, **kwds)
  File /usr/lib/python3.11/unittest/async_case.py, line 131, in @run
    return super().run(result)
  File /usr/lib/python3.11/unittest/case.py, line 619, in @run
    self._callSetUp()
  File /usr/lib/python3.11/unittest/async_case.py, line 87, in @_callSetUp
    self._callAsync(self.asyncSetUp)
  File /usr/lib/python3.11/unittest/async_case.py, line 104, in @_callAsync
    return self._asyncioRunner.run(
  File /usr/lib/python3.11/asyncio/runners.py, line 118, in @run
    return self._loop.run_until_complete(task)
  File /usr/lib/python3.11/asyncio/base_events.py, line 640, in @run_until_complete
    self.run_forever()
  File /usr/lib/python3.11/asyncio/base_events.py, line 607, in @run_forever
    self._run_once()
  File /usr/lib/python3.11/asyncio/base_events.py, line 1884, in @_run_once
    event_list = self._selector.select(timeout)
  File /usr/lib/python3.11/selectors.py, line 468, in @select
    fd_event_list = self._selector.poll(timeout, max_ev)
  File /home/alan/viam/board_canaries/stack_printing.py, line 21, in @print_all_stacks
    stack = traceback.extract_stack(frame)
Stack for <Task pending name='Task-5' coro=<GpioTest.asyncSetUp() running at /home/alan/viam/board_canaries/./test_gpios.py:26> wait_for=<Future pending cb=[_chain_future.<locals>._call_check_cancel() at /usr/lib/python3.11/asyncio/futures.py:387, Task.task_wakeup()] created at /usr/lib/python3.11/asyncio/base_events.py:427> cb=[_run_until_complete_cb() at /usr/lib/python3.11/asyncio/base_events.py:180] created at /usr/lib/python3.11/asyncio/runners.py:100> (most recent call last):
  File "/home/alan/viam/board_canaries/./test_gpios.py", line 26, in asyncSetUp
    self.robot = await RobotClient.at_address(conf.address, opts)
```
and frankly, the important part would likely be inside the call to `RobotClient.at_address` that isn't directly shown. All this could really do is distinguish whether we've hung trying to connect to the robot, or hung trying to read/set a pin. Is this still useful? I'm unsure. Is there a way to make it more useful? Again, I'm unsure. What do you think?