### PR TITLE
don't write to slack on connection failure

### DIFF
--- a/test_gpios.py
+++ b/test_gpios.py
@@ -34,8 +34,7 @@ class GpioTest(unittest.IsolatedAsyncioTestCase):
             # on port 9090. We want to only send the signal to the latter.
             subprocess.run(["pkill", "-10", "-f", "viam-canary.json"],
                            shell=True)
-            slack_reporter.report_message(
-                "connection error during canary tests. Retrying...")
+            print("Connection error during canary tests. Retrying...")
             time.sleep(5)
             self.robot = await RobotClient.at_address(conf.address, opts)
 


### PR DESCRIPTION
Unless this causes a test failure, we don't really care about it on Slack. If it causes a test failure, it'll be written to the logs and we can see it there.

I haven't tried this out, but I'm pretty confident it's right. 