### PR TITLE
logs analysis should include today's date, to make metaanalysis easier

### DIFF
--- a/analyze_logs.sh
+++ b/analyze_logs.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ex # -e: exit early on any error. -x: write all commands to stderr
 
+date '+%Y-%m-%d'
+
 # See https://stackoverflow.com/a/1482133 for an explanation of this next line.
 # It gets the directory in which this script resides.
 this_dir="$(dirname -- "$( readlink -f -- "$0"; )")";


### PR DESCRIPTION
This is split out of https://github.com/viamrobotics/board_canaries/pull/30, to get a head start. The idea is that if we log the current date when analyzing the logs, the monitor can check whether the canaries have analyzed their tests each day and write to Slack if something has gone wrong. but to prevent it from writing to Slack on the very first day, we should start logging the date before then.