### PR TITLE
[RSDK-8108] the monitor crontab should use bash, not sh

### DIFF
--- a/monitor_crontab.txt
+++ b/monitor_crontab.txt
@@ -3,7 +3,9 @@
 # /etc/cron.d on that one board. You should modify CANARY_DIR to its actual value before copying
 # it over.
 
-SHELL=/bin/sh
+# If we ever need a virtual environment to run Python, remember to use bash as the shell, and not
+# just sh! The sh shell doesn't know what `source` is, so sourcing the venv fails.
+SHELL=/bin/bash
 
 # The canary tests run at 2:30 AM, the analysis runs at 2:45. If boards are still online at 3:00,
 # they probably ran the tests, so we should check on them then.


### PR DESCRIPTION
Not described in this repo is the fact that the pi5 canary refuses to install any Python packages outside of a virtual environment. So, on the pi5 I installed everything inside one, and then edited the repo on that board to source the venv before running the Python scripts. Specifically, I added the line `source venv/bin/activate` inside both `analyze_logs.sh` and `canary_tests.sh`. That all worked fine. 

When the pi5 became the canary monitor, I also added that line inside the new cron entry, but didn't notice that cron was using `sh` instead of `bash` as its shell! and `sh` does not define `source`, so sourcing the venv was failing as an unknown command. The two files mentioned previously both start with `#!/bin/bash`, which is why they worked but the cron job didn't!

Thanks to @dgottlieb for the help figuring this out.

The test of this PR comes tonight: if the pi5 canary can run the monitor script at 3:00 AM, then this PR is right, and if it fails again, I'll come up with something else...