### PR TITLE
stop the RDK server after updating (which likely started it up)

### DIFF
--- a/canary_tests.sh
+++ b/canary_tests.sh
@@ -25,10 +25,10 @@ chmod 755 viam-server
 ./viam-server --aix-install
 
 # It's possible that the config for the "normal" RDK on this board has components attached to it
-# because someone was working on that board recently. When we re-install the RDK on the previous
-# line, it restarts the "normal" RDK, even if it was previously stopped. This might take ownership
-# of the pins we want to test, so stop it (again) before starting the canary, or we'll get spurious
-# test failures!
+# because someone was working on the board recently. When we re-install the RDK on the previous
+# line, it restarts the "normal" RDK service, even if it was previously stopped. This might take
+# ownership of the pins we want to test, so stop it before starting the canary, or we could get
+# spurious test failures!
 systemctl stop viam-server
 
 systemctl start viam-canary

--- a/canary_tests.sh
+++ b/canary_tests.sh
@@ -19,15 +19,17 @@ pushd "$this_dir" > /dev/null
 
 systemctl stop viam-canary
 
-# It's possible that someone like Alan or Olivia was working on this board earlier in the day,
-# forgot to clean up what they were doing, and now the relevant pins are in use and can't also be
-# used by the canary tests. Stop what that was, so we don't get spurious test failures.
-systemctl stop viam-server
-
 # Install the latest rdk. Installing instead of upgrading to ensure we get the latest version and don't get stuck on stable.
 curl "https://storage.googleapis.com/packages.viam.com/apps/viam-server/viam-server-latest-$(uname -m).AppImage" -o viam-server
 chmod 755 viam-server
 ./viam-server --aix-install
+
+# It's possible that the config for the "normal" RDK on this board has components attached to it
+# because someone was working on that board recently. When we re-install the RDK on the previous
+# line, it restarts the "normal" RDK, even if it was previously stopped. This might take ownership
+# of the pins we want to test, so stop it (again) before starting the canary, or we'll get spurious
+# test failures!
+systemctl stop viam-server
 
 systemctl start viam-canary
 sleep 120 # The server takes some time to set up its connections; don't talk to it too soon.


### PR DESCRIPTION
Tried on the Orin Nano: without this change, running `canary_tests.sh` failed because the pins were in use by a motor component on the normal RDK config. With this change, running it passed!