### PR TITLE
[RSDK-8519] Do everything from a virtual environment

### DIFF
--- a/analyze_logs.sh
+++ b/analyze_logs.sh
@@ -8,6 +8,8 @@ date '+%Y-%m-%d'
 this_dir="$(dirname -- "$( readlink -f -- "$0"; )")";
 pushd "$this_dir" > /dev/null
 
+source venv/bin/activate
+
 # The sed line keeps only the file contents that match the current date and
 # later. This solution was taken from https://stackoverflow.com/a/7104422
 cat /var/log/canary_tests.log |\

--- a/canary_tests.sh
+++ b/canary_tests.sh
@@ -36,6 +36,7 @@ sleep 120 # The server takes some time to set up its connections; don't talk to 
 
 git pull --ff-only origin main # Update the test script if necessary
 
+source venv/bin/activate
 pip install -r requirements.txt # Install any new dependencies
 
 echo "running tests..."

--- a/check_slack_connectivity.py
+++ b/check_slack_connectivity.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-import slack_reporter
+try:
+    import slack_reporter
+except:
+    print("\n\n Unable to import Slack stuff! Did you remember to run "
+          "`source venv/bin/activate`?\n\n")
+    raise
 
 
 # This is simultaneously:

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,10 @@ pushd "$this_dir" > /dev/null
 # job, even if the repo is owned by a normal non-root user."
 git config --global --add safe.directory "$this_dir"
 
+# Create a virtual environment.
+python -m venv venv
+source venv/bin/activate
+
 pip install -r requirements.txt
 
 # Install the RDK server

--- a/monitor_crontab.txt
+++ b/monitor_crontab.txt
@@ -9,4 +9,4 @@ SHELL=/bin/bash
 
 # The canary tests run at 2:30 AM, the analysis runs at 2:45. If boards are still online at 3:00,
 # they probably ran the tests, so we should check on them then.
-00 3 * * *   root   CANARY_DIR/monitor_other_boards.py >> /var/log/canary_monitor.log 2>&1
+00 3 * * *   root   cd CANARY_DIR && source venv/bin/activate && ./monitor_other_boards.py >> /var/log/canary_monitor.log 2>&1


### PR DESCRIPTION
We've now had 2 boards that cannot install python stuff without a virtual environment, so let's switch the board canaries to doing everything in one, and then we won't have this problem again.

Before merging this, we need virtual environments on every pre-existing board. No need to install stuff within it; that would happen all over again when canary_tests.sh runs overnight.