### PR TITLE
reload cron daemon after installing crontab

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -36,6 +36,7 @@ systemctl daemon-reload
 # the more traditional '/' because there are slashes within $this_dir and we don't want too many
 # slashes to confuse the parser.
 cat crontab_template.txt | sed "s%CANARY_DIR%$this_dir%g" > /etc/cron.d/viam-board-canary
+sudo service cron reload
 
 # Remind the user of the steps they need to do manually
 set +x # Stop printing every line: we're going to print them ourselves


### PR DESCRIPTION
Otherwise, the daemon won't notice the new file exists, and won't run the tests! I wonder if there are other boards that are mistakenly not running tests because the crontab didn't get picked up. :eyes: 

Solution taken from https://stackoverflow.com/questions/10193788/restarting-cron-after-changing-crontab-file#10193931