### PR TITLE
Update all boards to authenticate with API key instead of location secret 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Nightly unit test logs for all boards except the orange pi are located at `/var/
 - Clone this repo onto the board.
 - Run `sudo ./install.sh`
 - Follow the instructions printed at the end of that script:
-  - Copy `canary_config.example.py` into `canary_config.py`. Edit it to use the right location and secret, and the pins on the board you jumped together in the earlier step.
+  - Copy `canary_config.example.py` into `canary_config.py`. Edit it to use the correct address and API key, and the pins on the board you jumped together in the earlier step.
   - Copy `slack_reporter_config.example.py` into `slack_reporter_config.py`. Edit it so it can report to the correct Slack channel. To check that you set it up right, try running `./check_slack_connectivity.py`: if you did it right, you'll get a message in that Slack channel.
-  - Back in app.viam.com, find the `CONNECT` tab. Select `Python` under `Code Sample` and enable `Include secret`. Then copy the `RobotClient.Options.with_api_key` section and paste it to the `monitor_config.py` of the Pi5 canary.
+  - Back in app.viam.com, find the `CONNECT` tab. Select `Python` under `Code Sample` and enable `Include API Key`. Then copy the `opts` section and paste it to the `monitor_config.py` of the Pi5 canary.
 - Update the "Team Hardware" wiki with the login info. 

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ Nightly unit test logs for all boards except the orange pi are located at `/var/
 - Follow the instructions printed at the end of that script:
   - Copy `canary_config.example.py` into `canary_config.py`. Edit it to use the correct address and API key, and the pins on the board you jumped together in the earlier step.
   - Copy `slack_reporter_config.example.py` into `slack_reporter_config.py`. Edit it so it can report to the correct Slack channel. To check that you set it up right, try running `./check_slack_connectivity.py`: if you did it right, you'll get a message in that Slack channel.
-  - Back in app.viam.com, find the `CONNECT` tab. Select `Python` under `Code Sample` and enable `Include API Key`. Then copy the `opts` section and paste it to the `monitor_config.py` of the Pi5 canary.
+  - Back in app.viam.com, find the `CONNECT` tab. Select `Python` under `Code Sample` and enable `Include API Key`. Then copy the `opts` section and the machine address and paste them into the `monitor_config.py` of the Pi5 canary.
 - Update the "Team Hardware" wiki with the login info. 

--- a/canary_config.example.py
+++ b/canary_config.example.py
@@ -11,9 +11,10 @@ OUTPUT_PIN = "15"
 SW_PWM_PIN = "20"
 SW_INTERRUPT_PIN = "21"
 
-creds = RobotClient.Options.with_api_key(
-    api_key="secret-api-key",
-    api_key_id="put-the-secret-id-here")
+opts = RobotClient.Options.with_api_key( 
+        api_key='<your api key>',
+        api_key_id='<your api key id>'
+ )
 address = "address-for-robot.viam.cloud"
 
 # Most canaries should leave this as None, but we need at least one to set it to whichever board is

--- a/canary_tests.py
+++ b/canary_tests.py
@@ -35,11 +35,7 @@ async def connect(address, opts):
 
 class PinTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
-        opts = RobotClient.Options(
-            refresh_interval=0,
-            dial_options=DialOptions(credentials=conf.creds)
-        )
-        self.robot = await connect(conf.address, opts)
+        self.robot = await connect(conf.address, conf.opts)
 
         self.board = Board.from_robot(self.robot, "board")
         self.input_pin = await self.board.gpio_pin_by_name(conf.INPUT_PIN)

--- a/canary_tests.py
+++ b/canary_tests.py
@@ -29,7 +29,7 @@ async def connect(address, opts):
                        shell=True)
         print("Connection error during canary tests. Retrying...")
         time.sleep(5)
-        robot = await RobotClient.at_address(conf.address, opts)
+        robot = await RobotClient.at_address(address, opts)
     return robot
 
 


### PR DESCRIPTION
Updating boards to connect to the robot with API key since location secret is deprecated. I manually updated all the board's configs except for the orin which is not online and will need to be updated later. 